### PR TITLE
cmd/instability.go: use current slice to add dependencies

### DIFF
--- a/cmd/instability.go
+++ b/cmd/instability.go
@@ -37,7 +37,7 @@ func analyzeInstability(cmd *cobra.Command, args []string) {
 			utils.PrintStep()
 			impl.FillDependencies(pkgsInfo[index], pkgsInfo)
 			for _, current := range pkgInfo.Dependencies.Internals {
-				afferentMap[current] = append(afferentMap[pkgInfo.Path], current)
+				afferentMap[current] = append(afferentMap[current], pkgInfo.Path)
 			}
 		}
 		for index, pkgInfo := range pkgsInfo {


### PR DESCRIPTION
This should add the value to the current slice instead of adding the value to the slice is referring to. Please refer to the attached zipped HTML files for a better explanation.

[spm-go.zip](https://github.com/fdaines/spm-go/files/6674551/spm-go.zip)

![Screen Shot 2021-06-18 at 12 22 24 AM](https://user-images.githubusercontent.com/104050/122505925-4fdb1280-cfcb-11eb-9e25-ce305c3f9886.png)

![Screen Shot 2021-06-18 at 12 23 07 AM](https://user-images.githubusercontent.com/104050/122505960-608b8880-cfcb-11eb-828a-abeb43f5432f.png)


