### PR TITLE
Messy pull request... ignore this one

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ var context = build.Default
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&common.OutputFormat, "format", "f", "console", "Output format")
+	rootCmd.PersistentFlags().StringVarP(&common.MainPackage, "main-package", "m", "main", "choose which package to use as mainPackage")
 	rootCmd.PersistentFlags().BoolVarP(&common.Verbose, "verbose", "v", false, "Verbose Output")
 	rootCmd.PersistentFlags().BoolVar(&common.HtmlOutput, "html", false, "Generate HTML Output")
 }

--- a/common/flags.go
+++ b/common/flags.go
@@ -3,3 +3,4 @@ package common
 var OutputFormat string
 var Verbose bool
 var HtmlOutput bool
+var MainPackage string

--- a/utils/packages/get_main_package.go
+++ b/utils/packages/get_main_package.go
@@ -5,11 +5,15 @@ import (
 	"golang.org/x/mod/modfile"
 	"io/ioutil"
 	"os"
+	"github.com/fdaines/spm-go/common"
 )
 
 const goModFile = "go.mod"
 
 func GetMainPackage() (string, error) {
+	if common.MainPackage != "main" {
+		return common.MainPackage, nil
+	}
 	if _, err := os.Stat(goModFile); err == nil {
 		content, _ := ioutil.ReadFile(goModFile)
 		modulePath := modfile.ModulePath(content)


### PR DESCRIPTION
This _works_ with older versions of Go projects, with a few caveats:

- Environment variable **GO111MODULE** should be disabled
- Projects must reside within the Go SRC folder (or be in the GOPATH)

This would close https://github.com/fdaines/spm-go/issues/4

for example:
`GO111MODULE=off spm-go abstractness --main-package k8s.io/kubernetes -f csv`