### PR TITLE
Add support for older projects without go.mod, adding a new flag 'main-package'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $ spm-go command [flags]
 | --format  | Specifies the output format for the command. Supported values are: _json_, _console_ and _csv_. |
 | --verbose | Includes detailed information while the command is running                                      |
 | --html    | Creates an HTML report                                                                          |
+| --main-package | Allows user to specify the location of the main package, for projects prior to Go 1.11     |
 
 
 ## Examples
@@ -93,6 +94,7 @@ $ spm-go instability --verbose
 $ spm-go abstractness -f csv
 $ spm-go distance --format json
 $ spm-go all -v -f json
+$ spm-gp all -m k8s.io/kubernetes -v
 ```
 
 ## Output Formats

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"errors"
+	"go/build"
+	"os"
+
 	"github.com/fdaines/spm-go/common"
 	"github.com/fdaines/spm-go/utils"
 	"github.com/spf13/cobra"
-	"go/build"
-	"os"
 )
 
 func Execute() {
@@ -28,6 +29,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&common.OutputFormat, "format", "f", "console", "Output format")
 	rootCmd.PersistentFlags().BoolVarP(&common.Verbose, "verbose", "v", false, "Verbose Output")
 	rootCmd.PersistentFlags().BoolVar(&common.HtmlOutput, "html", false, "Generate HTML Output")
+	rootCmd.PersistentFlags().StringVarP(&common.MainPackage, "main-package", "m", "main", "choose which package to use as mainPackage")
 }
 
 func ValidateArgs(cmd *cobra.Command, args []string) error {

--- a/common/flags.go
+++ b/common/flags.go
@@ -3,3 +3,4 @@ package common
 var OutputFormat string
 var Verbose bool
 var HtmlOutput bool
+var MainPackage string

--- a/utils/packages/get_main_package.go
+++ b/utils/packages/get_main_package.go
@@ -2,14 +2,19 @@ package packages
 
 import (
 	"fmt"
-	"golang.org/x/mod/modfile"
 	"io/ioutil"
 	"os"
+
+	"github.com/fdaines/spm-go/common"
+	"golang.org/x/mod/modfile"
 )
 
 const goModFile = "go.mod"
 
 func GetMainPackage() (string, error) {
+	if common.MainPackage != "main" {
+		return common.MainPackage, nil
+	}
 	if _, err := os.Stat(goModFile); err == nil {
 		content, _ := ioutil.ReadFile(goModFile)
 		modulePath := modfile.ModulePath(content)


### PR DESCRIPTION
This _works_ with older versions of Go projects, with a few caveats:

- Environment variable **GO111MODULE** should be disabled
- Projects must reside within the Go SRC folder (or be in the GOPATH)

This would close https://github.com/fdaines/spm-go/issues/4

for example:
`GO111MODULE=off spm-go abstractness --main-package k8s.io/kubernetes -f csv`